### PR TITLE
Faster RCNN

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "catkin_ws/src/ros_faster_rcnn"]
+	path = catkin_ws/src/ros_faster_rcnn
+	url = https://github.com/ChielBruin/ros_faster_rcnn.git

--- a/catkin_ws/src/image_processing/CMakeLists.txt
+++ b/catkin_ws/src/image_processing/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
 	std_msgs
 	sensor_msgs
 	cucumber_msgs
+	ros_faster_rcnn
 )
 
 ################################################
@@ -42,9 +43,8 @@ target_link_libraries(cVis
 )
 add_dependencies(cVis
 	cucumber_msgs_generate_messages_cpp
+	ros_faster_rcnn_generate_messages_cpp
 )
-
-
 
 add_executable(IdCB src/IdCB/node_IdCB.cpp)
 target_link_libraries(IdCB

--- a/catkin_ws/src/image_processing/package.xml
+++ b/catkin_ws/src/image_processing/package.xml
@@ -24,6 +24,7 @@
 	<build_depend>roscpp</build_depend>
 
 	<build_depend>cucumber_msgs</build_depend>
+	<build_depend>ros_faster_rcnn</build_depend>
 	<build_depend>message_generation</build_depend>
 
 
@@ -33,6 +34,7 @@
 	<run_depend>roscpp</run_depend>
 
 	<run_depend>cucumber_msgs</run_depend>
+	<run_depend>ros_faster_rcnn</run_depend>
 	<run_depend>message_runtime</run_depend>
 
 

--- a/catkin_ws/src/image_processing/src/cVis/cVis.cpp
+++ b/catkin_ws/src/image_processing/src/cVis/cVis.cpp
@@ -1,10 +1,40 @@
 #include "cucumber_msgs/CucumberContainer.h"
+#include "ros_faster_rcnn/Detection.h"
 
 #include "sensor_msgs/Image.h"
 
-std::vector<CucumberContainer> processImage(sensor_msgs::Image image) {
-	std::vector<CucumberContainer> res;
+#define HEIGHT_OFFSET 0
+
+/**
+ * Check if the detected object is valid.
+ * This is done by validation of the object class and certainty of the detection.
+ */
+bool checkDetection(ros_faster_rcnn::Detection det) {
+	bool name = det.object.compare("Cucumber") == 0;
+	bool p = det.p > .8;
+	return name && p;
+}
+
+/**
+ * Calculates the curvature of the detected cucumber.
+ */
+float calculateCurvature(float width, float height) {
 	//TODO
+	return 0;
+}
+
+/**
+ * Processes the detection and produces a CucumberContainer object.
+ */
+CucumberContainer processDetection(ros_faster_rcnn::Detection det) {	
+	float width = det.width;
+	float height = det.height;
 	
+	float x = det.x + (width * .5);
+	float y = det.y + (height * HEIGHT_OFFSET);
+	
+	float curvature = calculateCurvature(det.width, det.height);
+	
+	CucumberContainer res = CucumberContainer(x, y, width, height, curvature);
 	return res;
 }

--- a/catkin_ws/src/image_processing/src/cVis/cVis.cpp
+++ b/catkin_ws/src/image_processing/src/cVis/cVis.cpp
@@ -10,7 +10,7 @@
  * This is done by validation of the object class and certainty of the detection.
  */
 bool checkDetection(ros_faster_rcnn::Detection det) {
-	bool name = det.object.compare("Cucumber") == 0;
+	bool name = det.object_class.compare("Cucumber") == 0;
 	bool p = det.p > .8;
 	return name && p;
 }

--- a/catkin_ws/src/image_processing/src/cVis/node_cVis.cpp
+++ b/catkin_ws/src/image_processing/src/cVis/node_cVis.cpp
@@ -3,24 +3,31 @@
 #include "ros/ros.h"
 #include "sensor_msgs/Image.h"
 #include "cucumber_msgs/Cucumber.h"
+#include "ros_faster_rcnn/Detection.h"
 
 using namespace ros;
 
 const std::string SIDE = "left";
 Publisher cucumber_pub;
+Publisher rcnn_pub;
  
 /**
  * Callback used when images are received.
- * Passes the image to the processing algorithm and publishes a message for each cucumber detected.
+ * Passes the image to the processing node.
  */
 void imageCallback(const sensor_msgs::Image& image) {
-	std::vector<CucumberContainer> res = processImage(image);
-	for (auto &c : res) {
-		cucumber_msgs::Cucumber msg = c.toMessage();
-		 msg.header = image.header;
-		 msg.dimension = cucumber_msgs::Cucumber::DIM_2D;
-		cucumber_pub.publish(msg);
-	} 
+	rcnn_pub.publish(image);
+}
+
+/**
+ * Callback for receiving detections from the detection node
+ * Parses the detected cucumbers toa cucumber message and publishes it.
+ */
+void detectionCallback(const ros_faster_rcnn::Detection& det) {
+	if (! checkDetection(det)) return;
+	cucumber_msgs::Cucumber msg = processDetection(det).toMessage();
+	 msg.header = det.header;
+	cucumber_pub.publish(msg);
 }
 
 /**
@@ -34,6 +41,9 @@ int main(int argc, char **argv) {
 	NodeHandle n;
 	cucumber_pub = n.advertise<cucumber_msgs::Cucumber>(SIDE + "/cucumber", 20);
 	Subscriber image_sub = n.subscribe(SIDE + "/image_raw", 1000, imageCallback);
+	
+	rcnn_pub = n.advertise<sensor_msgs::Image>("rcnn/camera_raw", 20);
+	Subscriber detector_sub = n.subscribe("rcnn/detections", 1000, detectionCallback);
 
 	spin();
 	return 0;


### PR DESCRIPTION
# This PR should be merged after #1
- Added the [faster RCNN wrapper](https://github.com/ChielBruin/ros_faster_rcnn) to the framework. 
 This wrapper performs the image classification and returns a list of detected objects.
- Updated the Cvis node to be able to interface the faster RCNN wrapper
