### PR TITLE
Added environment objects to planning scene.

### DIFF
--- a/catkin_ws/src/kpr_arm_control/CMakeLists.txt
+++ b/catkin_ws/src/kpr_arm_control/CMakeLists.txt
@@ -17,6 +17,8 @@ find_package(catkin REQUIRED COMPONENTS
 	ur_bringup
 	ur5_moveit_config
 	ur_msgs
+
+	rviz
 )
 
 ################################################

--- a/catkin_ws/src/kpr_arm_control/launch/arm.launch
+++ b/catkin_ws/src/kpr_arm_control/launch/arm.launch
@@ -4,6 +4,7 @@
 	<arg name="robot_ip" default="127.0.0.1"/>
 	<arg name="limited" default="true"/>
 	<arg name="testing" default="false"/>
+	<arg name="enable_rviz" default="false"/>
 
 	<include file="$(find ur_bringup)/launch/ur5_bringup.launch"> 
 		<arg name="robot_ip" value="$(arg robot_ip)"/>
@@ -17,4 +18,9 @@
 	<node name="armControl" pkg="kpr_arm_control" type="arm_control">
 		<remap if="$(arg testing)" from="set_io" to="set_io_testing"/>
 	</node>
+
+	<include if="$(arg enable_rviz)" file="$(find ur5_moveit_config)/launch/moveit_rviz.launch">
+		<arg name="config" value="true"/>
+		<arg name="debug" value="false"/>
+	</include>
 </launch>

--- a/catkin_ws/src/kpr_arm_control/package.xml
+++ b/catkin_ws/src/kpr_arm_control/package.xml
@@ -43,6 +43,8 @@
 	<run_depend>moveit_core</run_depend>
 	<run_depend>moveit_msgs</run_depend>
 
+	<run_depend>rviz</run_depend>
+
 	<run_depend>cucumber_msgs</run_depend>
 
 	<run_depend>shape_msgs</run_depend>

--- a/catkin_ws/src/kpr_arm_control/package.xml
+++ b/catkin_ws/src/kpr_arm_control/package.xml
@@ -7,12 +7,10 @@
 	<maintainer email="max_groenenboom@hotmail.com">Max Groenenboom</maintainer>
 	<author email="max_groenenboom@hotmail.com">Max Groenenboom</author>
 
-
 	<!-- One license tag required, multiple allowed, one license per tag -->
 	<!-- Commonly used license strings: -->
 	<!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
 	<license>TODO</license>
-
 
 	<url type="repository">https://github.com/ChielBruin/tomatenplukkers</url>
 
@@ -31,6 +29,8 @@
 
 	<build_depend>cucumber_msgs</build_depend>
 
+	<build_depend>shape_msgs</build_depend>
+
 	<run_depend>geometry_msgs</run_depend>
 	<run_depend>std_msgs</run_depend>
 	<run_depend>roscpp</run_depend>
@@ -44,4 +44,6 @@
 	<run_depend>moveit_msgs</run_depend>
 
 	<run_depend>cucumber_msgs</run_depend>
+
+	<run_depend>shape_msgs</run_depend>
 </package>

--- a/catkin_ws/src/kpr_arm_control/src/arm_control/node_arm_control.cpp
+++ b/catkin_ws/src/kpr_arm_control/src/arm_control/node_arm_control.cpp
@@ -5,18 +5,24 @@
 #include "cucumber_msgs/HarvestAction.h"
 #include "cucumber_msgs/Cucumber.h"
 #include "cucumber_msgs/CucumberContainer.h"
-#include "geometry_msgs/Pose.h"
-#include "geometry_msgs/Quaternion.h"
 
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/Quaternion.h>
 #include <ur_msgs/SetIO.h>
+#include <shape_msgs/SolidPrimitive.h>
+#include <moveit_msgs/PlanningScene.h>
 
 #include <moveit/move_group_interface/move_group.h>
 #include <moveit/planning_scene_interface/planning_scene_interface.h>
+#include <moveit/robot_model_loader/robot_model_loader.h>
+#include <moveit/planning_scene/planning_scene.h>
 
 using namespace ros;
 
 const std::string NODE_NAME = "Arm Control";
 const std::string move_group_name("manipulator");
+
+Publisher planning_scene_diff_publisher;
 
 /**
  * Attempts to pick a cucumber. This function does the following things:
@@ -100,6 +106,39 @@ void setupMoveIt(NodeHandle n) {
 
 	ROS_INFO("Reference frame: %s", move_group_ptr->getPlanningFrame().c_str());
 	ROS_INFO("Reference frame: %s", move_group_ptr->getEndEffectorLink().c_str());
+
+	planning_scene_diff_publisher = n.advertise<moveit_msgs::PlanningScene>("planning_scene", 1);
+
+	moveit_msgs::AttachedCollisionObject attached_object;
+	attached_object.link_name = "base_link";
+	attached_object.object.header.frame_id = "table_attach";
+	attached_object.object.id = "table";
+
+	geometry_msgs::Pose pose;
+	pose.position.z = -0.05;
+	pose.orientation.w = 1.0;
+
+	shape_msgs::SolidPrimitive primitive;
+	primitive.type = primitive.BOX;
+	primitive.dimensions.resize(3);
+	primitive.dimensions[0] = 1.5;
+	primitive.dimensions[1] = 1;
+	primitive.dimensions[2] = 0.1;
+
+	attached_object.object.primitives.push_back(primitive);
+	attached_object.object.primitive_poses.push_back(pose);
+	attached_object.object.operation = attached_object.object.ADD;
+
+	// Wait until the publisher is connected.
+	WallDuration sleep_t(0.1);
+	while(planning_scene_diff_publisher.getNumSubscribers() < 1) {
+		sleep_t.sleep();
+	}
+
+	moveit_msgs::PlanningScene planning_scene;
+	planning_scene.world.collision_objects.push_back(attached_object.object);
+	planning_scene.is_diff = true;
+	planning_scene_diff_publisher.publish(planning_scene);
 }
 
 /**

--- a/catkin_ws/src/kpr_arm_control/src/arm_control/node_arm_control.cpp
+++ b/catkin_ws/src/kpr_arm_control/src/arm_control/node_arm_control.cpp
@@ -150,22 +150,18 @@ void addEndEffector() {
 	endEffector.object.header.frame_id = "end_effector_attach";
 	endEffector.object.id = "end_effector";
 
-	geometry_msgs::Pose eePose;
 	// Translates the end effector to the end of the arm.
 	// Should not be necessary but currently the built-in translation breaks.
 	//TODO Make sure the built-in translation is used instead of this work around.
-	eePose.position.x = 0.81725;
-	eePose.position.y = 0.19145;
-	eePose.position.z = -0.005491;
+	geometry_msgs::Pose eePose = move_group_ptr->getCurrentPose().pose;
 
 	eePose.position.y += 0.16/2;
-	eePose.orientation.w = 1.0;
 
 	shape_msgs::SolidPrimitive eeBox;
 	eeBox.type = eeBox.BOX;
 	eeBox.dimensions.resize(3);
-	eeBox.dimensions[eeBox.BOX_X] = 0.075;
-	eeBox.dimensions[eeBox.BOX_Y] = 0.16;
+	eeBox.dimensions[eeBox.BOX_X] = 0.16;
+	eeBox.dimensions[eeBox.BOX_Y] = 0.075;
 	eeBox.dimensions[eeBox.BOX_Z] = 0.075;
 
 	endEffector.object.primitives.push_back(eeBox);

--- a/catkin_ws/src/kpr_arm_control/src/arm_control/node_arm_control.cpp
+++ b/catkin_ws/src/kpr_arm_control/src/arm_control/node_arm_control.cpp
@@ -1,5 +1,6 @@
 #include "ros/ros.h"
 #include "arm_control.cpp"
+#include "planning_scene_objects.cpp"
 #include <memory>
 
 #include "cucumber_msgs/HarvestAction.h"
@@ -10,7 +11,6 @@
 #include <geometry_msgs/Quaternion.h>
 #include <ur_msgs/SetIO.h>
 #include <shape_msgs/SolidPrimitive.h>
-#include <moveit_msgs/PlanningScene.h>
 #include <sensor_msgs/PointCloud2.h>
 
 #include <moveit/move_group_interface/move_group.h>
@@ -94,90 +94,11 @@ bool getCucumber(cucumber_msgs::HarvestAction::Request &msg,
 }
 
 /**
- * Adds the table the arm stands on to the planning scene, to prevent the
- * arm from breaking itself and the end effector. Also adds a backpanel
- * because the arm won't be able to navigate too far backwards because
- * another row of cucumber plants will be there, which won't be visible.
- */
-void addTable() {
-	// Offset because the base continues slightly below its link.
-	const float HEIGHT_OFFSET = 0.004;
-
-	moveit_msgs::AttachedCollisionObject table;
-	table.link_name = "world";
-	table.object.header.frame_id = "table_attach";
-	table.object.id = "table";
-
-	geometry_msgs::Pose tablePose;
-	tablePose.position.z = -0.1/2 - HEIGHT_OFFSET;
-	tablePose.orientation.w = 1.0;
-
-	shape_msgs::SolidPrimitive tableBox;
-	tableBox.type = tableBox.BOX;
-	tableBox.dimensions.resize(3);
-	tableBox.dimensions[tableBox.BOX_X] = 1.5;
-	tableBox.dimensions[tableBox.BOX_Y] = 1;
-	tableBox.dimensions[tableBox.BOX_Z] = 0.1;
-
-	table.object.primitives.push_back(tableBox);
-	table.object.primitive_poses.push_back(tablePose);
-
-	geometry_msgs::Pose backpanelPose;
-	backpanelPose.position.y = -0.3;
-	backpanelPose.position.z = 0.5 - HEIGHT_OFFSET;
-	backpanelPose.orientation.w = 1.0;
-
-	shape_msgs::SolidPrimitive backpanelBox;
-	backpanelBox.type = backpanelBox.BOX;
-	backpanelBox.dimensions.resize(3);
-	backpanelBox.dimensions[backpanelBox.BOX_X] = 1.5;
-	backpanelBox.dimensions[backpanelBox.BOX_Y] = 0.1;
-	backpanelBox.dimensions[backpanelBox.BOX_Z] = 1;
-
-	table.object.primitives.push_back(backpanelBox);
-	table.object.primitive_poses.push_back(backpanelPose);
-	table.object.operation = table.object.ADD;
-
-	aco_publisher.publish(table);
-}
-
-/**
- * Adds the temporary end effector, to prevent the arm from breaking the
- * real end effector and to be able to properly align with the cucumber.
- */
-void addEndEffector() {
-	moveit_msgs::AttachedCollisionObject endEffector;
-	endEffector.link_name = "ee_link";
-	endEffector.object.header.frame_id = "end_effector_attach";
-	endEffector.object.id = "end_effector";
-
-	// Translates the end effector to the end of the arm.
-	// Should not be necessary but currently the built-in translation breaks.
-	//TODO Make sure the built-in translation is used instead of this work around.
-	geometry_msgs::Pose eePose = move_group_ptr->getCurrentPose().pose;
-
-	eePose.position.y += 0.16/2;
-
-	shape_msgs::SolidPrimitive eeBox;
-	eeBox.type = eeBox.BOX;
-	eeBox.dimensions.resize(3);
-	eeBox.dimensions[eeBox.BOX_X] = 0.16;
-	eeBox.dimensions[eeBox.BOX_Y] = 0.075;
-	eeBox.dimensions[eeBox.BOX_Z] = 0.075;
-
-	endEffector.object.primitives.push_back(eeBox);
-	endEffector.object.primitive_poses.push_back(eePose);
-	endEffector.object.operation = endEffector.object.ADD;
-
-	aco_publisher.publish(endEffector);
-}
-
-/**
  * Adds the objects in the scene. (table and end effector).
  */
 void addSceneObjects() {
-	addTable();
-	addEndEffector();
+	aco_publisher.publish(createTable());
+	aco_publisher.publish(createEndEffector());
 }
 
 /**

--- a/catkin_ws/src/kpr_arm_control/src/arm_control/node_arm_control.cpp
+++ b/catkin_ws/src/kpr_arm_control/src/arm_control/node_arm_control.cpp
@@ -11,6 +11,7 @@
 #include <ur_msgs/SetIO.h>
 #include <shape_msgs/SolidPrimitive.h>
 #include <moveit_msgs/PlanningScene.h>
+#include <sensor_msgs/PointCloud2.h>
 
 #include <moveit/move_group_interface/move_group.h>
 #include <moveit/planning_scene_interface/planning_scene_interface.h>

--- a/catkin_ws/src/kpr_arm_control/src/arm_control/planning_scene_objects.cpp
+++ b/catkin_ws/src/kpr_arm_control/src/arm_control/planning_scene_objects.cpp
@@ -1,0 +1,80 @@
+
+
+/**
+ * Adds the table the arm stands on to the planning scene, to prevent the
+ * arm from breaking itself and the end effector. Also adds a backpanel
+ * because the arm won't be able to navigate too far backwards because
+ * another row of cucumber plants will be there, which won't be visible.
+ */
+moveit_msgs::AttachedCollisionObject createTable() {
+	// Offset because the base continues slightly below its link.
+	const float HEIGHT_OFFSET = 0.004;
+
+	moveit_msgs::AttachedCollisionObject table;
+	table.link_name = "world";
+	table.object.header.frame_id = "table_attach";
+	table.object.id = "table";
+
+	geometry_msgs::Pose tablePose;
+	tablePose.position.z = -0.1/2 - HEIGHT_OFFSET;
+	tablePose.orientation.w = 1.0;
+
+	shape_msgs::SolidPrimitive tableBox;
+	tableBox.type = tableBox.BOX;
+	tableBox.dimensions.resize(3);
+	tableBox.dimensions[tableBox.BOX_X] = 1.5;
+	tableBox.dimensions[tableBox.BOX_Y] = 1;
+	tableBox.dimensions[tableBox.BOX_Z] = 0.1;
+
+	table.object.primitives.push_back(tableBox);
+	table.object.primitive_poses.push_back(tablePose);
+
+	geometry_msgs::Pose backpanelPose;
+	backpanelPose.position.y = -0.3;
+	backpanelPose.position.z = 0.5 - HEIGHT_OFFSET;
+	backpanelPose.orientation.w = 1.0;
+
+	shape_msgs::SolidPrimitive backpanelBox;
+	backpanelBox.type = backpanelBox.BOX;
+	backpanelBox.dimensions.resize(3);
+	backpanelBox.dimensions[backpanelBox.BOX_X] = 1.5;
+	backpanelBox.dimensions[backpanelBox.BOX_Y] = 0.1;
+	backpanelBox.dimensions[backpanelBox.BOX_Z] = 1;
+
+	table.object.primitives.push_back(backpanelBox);
+	table.object.primitive_poses.push_back(backpanelPose);
+	table.object.operation = table.object.ADD;
+
+	return table;
+}
+
+/**
+ * Adds the temporary end effector, to prevent the arm from breaking the
+ * real end effector and to be able to properly align with the cucumber.
+ */
+moveit_msgs::AttachedCollisionObject createEndEffector() {
+	moveit_msgs::AttachedCollisionObject endEffector;
+	endEffector.link_name = "ee_link";
+	endEffector.object.header.frame_id = "end_effector_attach";
+	endEffector.object.id = "end_effector";
+
+	// Translates the end effector to the end of the arm.
+	// Should not be necessary but currently the built-in translation breaks.
+	//TODO Make sure the built-in translation is used instead of this work around.
+	geometry_msgs::Pose eePose = move_group_ptr->getCurrentPose().pose;
+
+	eePose.position.y += 0.16/2;
+
+	shape_msgs::SolidPrimitive eeBox;
+	eeBox.type = eeBox.BOX;
+	eeBox.dimensions.resize(3);
+	eeBox.dimensions[eeBox.BOX_X] = 0.16;
+	eeBox.dimensions[eeBox.BOX_Y] = 0.075;
+	eeBox.dimensions[eeBox.BOX_Z] = 0.075;
+
+	endEffector.object.primitives.push_back(eeBox);
+	endEffector.object.primitive_poses.push_back(eePose);
+	endEffector.object.operation = endEffector.object.ADD;
+
+	return endEffector;
+}

--- a/catkin_ws/src/kpr_launch/launch/robot.launch
+++ b/catkin_ws/src/kpr_launch/launch/robot.launch
@@ -8,6 +8,8 @@
 
 	<arg name="cpu_mode" default="false"/>
 	<arg name="enable_faster_rcnn" default="true"/>
+	
+	<arg name="enable_rviz" default="false"/>
 
 	<!-- Launch the interface -->
 	<include if="$(arg enable_gui)" file="$(find kpr_interface)/launch/interface.launch"/>
@@ -16,6 +18,7 @@
 	<include file="$(find kpr_arm_control)/launch/arm.launch">
 		<arg name="robot_ip" value="$(arg robot_ip)"/>
 		<arg name="limited" value="$(arg limited)"/>
+		<arg name="enable_rviz" value="$(arg enable_rviz"/>
 	</include>
 
 	<!-- Launch fasterRCNN -->

--- a/catkin_ws/src/kpr_launch/launch/robot.launch
+++ b/catkin_ws/src/kpr_launch/launch/robot.launch
@@ -18,7 +18,7 @@
 	<include file="$(find kpr_arm_control)/launch/arm.launch">
 		<arg name="robot_ip" value="$(arg robot_ip)"/>
 		<arg name="limited" value="$(arg limited)"/>
-		<arg name="enable_rviz" value="$(arg enable_rviz"/>
+		<arg name="enable_rviz" value="$(arg enable_rviz)"/>
 	</include>
 
 	<!-- Launch fasterRCNN -->

--- a/catkin_ws/src/kpr_launch/launch/testing.launch
+++ b/catkin_ws/src/kpr_launch/launch/testing.launch
@@ -26,6 +26,7 @@
 		<arg name="robot_ip" value="$(arg robot_ip)"/>
 		<arg name="limited" value="$(arg limited)"/>
 		<arg name="testing" value="true"/>
+		<arg name="enable_rviz" value="true"/>
 	</include>
 
 	<!-- Launch fasterRCNN -->

--- a/catkin_ws/src/universal_robot/ur5_moveit_config/config/sensors_bumblebee.yaml
+++ b/catkin_ws/src/universal_robot/ur5_moveit_config/config/sensors_bumblebee.yaml
@@ -1,9 +1,9 @@
 sensors:
   - sensor_plugin: occupancy_map_monitor/PointCloudOctomapUpdater
-    point_cloud_topic: points
+    point_cloud_topic: /camera/points2
     #//TODO enter correct values
     max_range: 2.0
     point_subsample: 1
     padding_offset: 0.1
     padding_scale: 0.1
-    filtered_cloud_topic: filtered_cloud
+    filtered_cloud_topic: /filtered_cloud

--- a/catkin_ws/src/universal_robot/ur5_moveit_config/config/sensors_bumblebee.yaml
+++ b/catkin_ws/src/universal_robot/ur5_moveit_config/config/sensors_bumblebee.yaml
@@ -1,0 +1,8 @@
+sensors:
+  - sensor_plugin: occupancy_map_monitor/PointCloudOctomapUpdater
+    point_cloud_topic: points
+    max_range: 2.0 //TODO add values.
+    point_subsample: 
+    padding_offset: 
+    padding_scale: 
+    filtered_cloud_topic: filtered_cloud

--- a/catkin_ws/src/universal_robot/ur5_moveit_config/config/sensors_bumblebee.yaml
+++ b/catkin_ws/src/universal_robot/ur5_moveit_config/config/sensors_bumblebee.yaml
@@ -2,8 +2,8 @@ sensors:
   - sensor_plugin: occupancy_map_monitor/PointCloudOctomapUpdater
     point_cloud_topic: /camera/points2
     #//TODO enter correct values
-    max_range: 2.0
+    max_range: 3.0
     point_subsample: 1
     padding_offset: 0.1
-    padding_scale: 0.1
+    padding_scale: 1.0
     filtered_cloud_topic: /filtered_cloud

--- a/catkin_ws/src/universal_robot/ur5_moveit_config/config/sensors_bumblebee.yaml
+++ b/catkin_ws/src/universal_robot/ur5_moveit_config/config/sensors_bumblebee.yaml
@@ -1,8 +1,9 @@
 sensors:
   - sensor_plugin: occupancy_map_monitor/PointCloudOctomapUpdater
     point_cloud_topic: points
-    max_range: 2.0 //TODO add values.
-    point_subsample: 
-    padding_offset: 
-    padding_scale: 
+    #//TODO enter correct values
+    max_range: 2.0
+    point_subsample: 1
+    padding_offset: 0.1
+    padding_scale: 0.1
     filtered_cloud_topic: filtered_cloud

--- a/catkin_ws/src/universal_robot/ur5_moveit_config/launch/moveit.rviz
+++ b/catkin_ws/src/universal_robot/ur5_moveit_config/launch/moveit.rviz
@@ -5,8 +5,9 @@ Panels:
     Property Tree Widget:
       Expanded:
         - /MotionPlanning1
+        - /PointCloud21
       Splitter Ratio: 0.74256
-    Tree Height: 291
+    Tree Height: 141
   - Class: rviz/Help
     Name: Help
   - Class: rviz/Views
@@ -39,20 +40,39 @@ Visualization Manager:
       Enabled: true
       Move Group Namespace: ""
       MoveIt_Goal_Tolerance: 0
-      MoveIt_Planning_Time: 0
       MoveIt_Planning_Attempts: 1
+      MoveIt_Planning_Time: 0
       MoveIt_Use_Constraint_Aware_IK: true
       MoveIt_Warehouse_Host: 127.0.0.1
       MoveIt_Warehouse_Port: 33829
+      MoveIt_Workspace:
+        Center:
+          X: 0
+          Y: 0
+          Z: 0
+        Size:
+          X: 2
+          Y: 2
+          Z: 2
       Name: MotionPlanning
       Planned Path:
+        Interrupt Display: false
         Links:
           All Links Enabled: true
           Expand Joint Details: false
           Expand Link Details: false
           Expand Tree: false
           Link Tree Style: Links in Alphabetic Order
+          base:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
           base_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          bumblebee:
             Alpha: 1
             Show Axes: false
             Show Trail: false
@@ -61,6 +81,7 @@ Visualization Manager:
             Alpha: 1
             Show Axes: false
             Show Trail: false
+            Value: true
           forearm_link:
             Alpha: 1
             Show Axes: false
@@ -71,6 +92,10 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
+          tool0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
           upper_arm_link:
             Alpha: 1
             Show Axes: false
@@ -138,7 +163,16 @@ Visualization Manager:
           Expand Link Details: false
           Expand Tree: false
           Link Tree Style: Links in Alphabetic Order
+          base:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
           base_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          bumblebee:
             Alpha: 1
             Show Axes: false
             Show Trail: false
@@ -147,6 +181,7 @@ Visualization Manager:
             Alpha: 1
             Show Axes: false
             Show Trail: false
+            Value: true
           forearm_link:
             Alpha: 1
             Show Axes: false
@@ -157,6 +192,10 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
+          tool0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
           upper_arm_link:
             Alpha: 1
             Show Axes: false
@@ -185,6 +224,36 @@ Visualization Manager:
         Show Robot Collision: false
         Show Robot Visual: true
       Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.01
+      Style: Flat Squares
+      Topic: /camera/points2
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -200,7 +269,7 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/XYOrbit
-      Distance: 2.9965
+      Distance: 1.07764
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.06
         Stereo Focal Distance: 1
@@ -212,10 +281,10 @@ Visualization Manager:
         Z: 2.23518e-07
       Name: Current View
       Near Clip Distance: 0.01
-      Pitch: 0.509797
+      Pitch: -0.114797
       Target Frame: world
       Value: XYOrbit (rviz)
-      Yaw: 5.65995
+      Yaw: 4.72995
     Saved: ~
 Window Geometry:
   Displays:
@@ -227,9 +296,9 @@ Window Geometry:
   Hide Right Dock: false
   Motion Planning:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd0000000100000000000002a20000031cfc0200000005fb000000100044006900730070006c0061007900730100000036000001b4000000b700fffffffb0000000800480065006c00700000000342000000bb0000006500fffffffb0000000a0056006900650077007300000003b0000000b00000009b00fffffffb0000000c00430061006d00650072006100000002ff000001610000000000000000fb0000001e004d006f00740069006f006e00200050006c0061006e006e0069006e006701000001f0000001620000015700ffffff000003570000031c00000001000000020000000100000002fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000100000000000002a200000309fc0200000005fb000000100044006900730070006c006100790073010000004300000124000000df00fffffffb0000000800480065006c00700000000342000000bb0000007800fffffffb0000000a0056006900650077007300000003b0000000b0000000b800fffffffb0000000c00430061006d00650072006100000002ff000001610000000000000000fb0000001e004d006f00740069006f006e00200050006c0061006e006e0069006e0067010000016d000001df000001d400ffffff000003570000030900000001000000020000000100000002fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Views:
     collapsed: false
   Width: 1535
-  X: 65
-  Y: 24
+  X: 56
+  Y: 16

--- a/catkin_ws/src/universal_robot/ur5_moveit_config/launch/ur5_moveit_sensor_manager.launch.xml
+++ b/catkin_ws/src/universal_robot/ur5_moveit_config/launch/ur5_moveit_sensor_manager.launch.xml
@@ -1,3 +1,6 @@
 <launch>
-
+	<rosparam command="load" file="$(find ur5_moveit_config)/config/sensors_bumblebee.yaml" />
+	<param name="octomap_frame" type="string" value="odom_combined" />
+	<param name="octomap_resolution" type="double" value="0.05" />
+	<param name="max_range" type="double" value="2.0" />
 </launch>

--- a/catkin_ws/src/universal_robot/ur_description/urdf/ur5.urdf.xacro
+++ b/catkin_ws/src/universal_robot/ur_description/urdf/ur5.urdf.xacro
@@ -99,6 +99,21 @@
       </xacro:cylinder_inertial>
     </link>
 
+	<link name="bumblebee" >
+		<visual>
+			<geometry>
+				<box size="0.1 0.02 0.02"/>
+			</geometry>
+			<origin rpy="0 0 0" xyz="0 0 0"/>
+		</visual>
+	</link>
+	
+	  <joint name="bumblebee_joint" type="fixed">
+		<parent link="base_link"/>
+		<child link="bumblebee"/>
+		<origin rpy="${-pi / 2} 0.0 0.0" xyz="0.0 0.1 0.01"/>
+	  </joint>
+
     <joint name="${prefix}shoulder_pan_joint" type="revolute">
       <parent link="${prefix}base_link" />
       <child link = "${prefix}shoulder_link" />


### PR DESCRIPTION
Added some environment objects to the MoveIt! planning scene:
- The table the arm stands on.
- A backpanel to prevent the arm from using the space behind it (there would be other plants there).
- A temporary box representing the gripper.

Also added the option to enable the MoveIt! planning interface for live runs and to make it automatically enabled for testing runs. This interface is needed to view the added planning scene collision objects.

A first version of point cloud usage by the collision model has been added as well, but this has not been tested yet, and it doesn't have real parameters.